### PR TITLE
Fix overflow bug when calculation pixel array length

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -37,7 +37,7 @@ func (*RawEncoding) Read(c *ClientConn, rect *Rectangle, r io.Reader) (Encoding,
 		byteOrder = binary.BigEndian
 	}
 
-	colors := make([]Color, rect.Height * rect.Width)
+	colors := make([]Color, int(rect.Height)*int(rect.Width))
 	for y := uint16(0); y < rect.Height; y++ {
 		for x := uint16(0); x < rect.Width; x++ {
 			if _, err := io.ReadFull(r, pixelBytes); err != nil {


### PR DESCRIPTION
When `width*height` of a rectangle overflows `uint16`, the allocated buffer is too small to hold the actual rectangle.