### PR TITLE
Replace internal image data structures with those from the standard library

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"unicode"
+	"image/color"
 )
 
 type ClientConn struct {
@@ -20,7 +21,7 @@ type ClientConn struct {
 	// If the pixel format uses a color map, then this is the color
 	// map that is used. This should not be modified directly, since
 	// the data comes from the server.
-	ColorMap [256]Color
+	ColorMap [256]color.RGBA
 
 	// Encodings supported by the client. This should not be modified
 	// directly. Instead, SetEncodings should be used.
@@ -271,10 +272,6 @@ func (c *ClientConn) SetPixelFormat(format *PixelFormat) error {
 	if _, err := c.c.Write(keyEvent[:]); err != nil {
 		return err
 	}
-
-	// Reset the color map as according to RFC.
-	var newColorMap [256]Color
-	c.ColorMap = newColorMap
 
 	return nil
 }

--- a/color.go
+++ b/color.go
@@ -1,6 +1,0 @@
-package vnc
-
-// Color represents a single color in a color map.
-type Color struct {
-	R, G, B uint16
-}


### PR DESCRIPTION
Hi Mitchell,

I suggest replacing the internal image/rectangle-related data structures that force the user to deal with all the details related to color depth etc. with `image/*` from the Go standard library so we can use the composition functions. This patch does just that.

I have successfully tested this on a Linux system using Xvnc4 in TrueColor mode and a small test program that composes rectangles from `FramebufferUpdateMessage`s into an internal Framebuffer (`image.RGBA`) and dumps that into files.

Cheers,
-Hilko
