### PR TITLE
- according to RFC, padding in ServerCutText is 3 bytes, not 1

### DIFF
--- a/server_messages.go
+++ b/server_messages.go
@@ -173,7 +173,7 @@ func (*ServerCutTextMessage) Type() uint8 {
 
 func (*ServerCutTextMessage) Read(c *ClientConn, r io.Reader) (ServerMessage, error) {
 	// Read off the padding
-	var padding [1]byte
+	var padding [3]byte
 	if _, err := io.ReadFull(r, padding[:]); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed amount of padding expected in ServerCutText message