### PR TITLE
Close server message channel when exiting main loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -465,6 +465,10 @@ func (c *ClientConn) mainLoop() {
 
 		c.config.ServerMessageCh <- parsedMsg
 	}
+
+	if c.config.ServerMessageCh != nil {
+		close(c.config.ServerMessageCh)
+	}
 }
 
 func (c *ClientConn) readErrorReason() string {


### PR DESCRIPTION
Allows the channel reader to detect that there are no more incoming messages on the channel, instead of just get stuck forever.