### PR TITLE
Fleshed out the client protocol unit tests.

### DIFF
--- a/client.go
+++ b/client.go
@@ -524,14 +524,16 @@ func (c *ClientConn) readErrorReason() (string, error) {
 	return string(reason), nil
 }
 
-type vncError struct {
+// VNCError implements error interface.
+type VNCError struct {
 	s string
 }
 
+// NewVNCError returns a custom VNCError error.
 func NewVNCError(s string) error {
-	return &vncError{s}
+	return &VNCError{s}
 }
 
-func (e vncError) Error() string {
+func (e VNCError) Error() string {
 	return e.s
 }

--- a/client.go
+++ b/client.go
@@ -300,13 +300,7 @@ func (c *ClientConn) SetPixelFormat(format *PixelFormat) error {
 	return nil
 }
 
-const (
-	pvLen = 12 // ProtocolVersion message length.
-
-	// Supported protocol versions.
-	PROTO_VERS_UNSUP = "UNSUP"
-	PROTO_VERS_3_8   = "003.008"
-)
+const pvLen = 12 // ProtocolVersion message length.
 
 func parseProtocolVersion(pv []byte) (uint, uint, error) {
 	var major, minor uint
@@ -325,6 +319,12 @@ func parseProtocolVersion(pv []byte) (uint, uint, error) {
 
 	return major, minor, nil
 }
+
+const (
+	// Client ProtocolVersions.
+	PROTO_VERS_UNSUP = "UNSUPPORTED"
+	PROTO_VERS_3_8   = "RFB 003.008\n"
+)
 
 // protocolVersionHandshake implements §7.1.1 ProtocolVersion Handshake.
 func (c *ClientConn) protocolVersionHandshake() error {
@@ -348,7 +348,7 @@ func (c *ClientConn) protocolVersionHandshake() error {
 	}
 
 	// Respond with the version we will support
-	if _, err = c.c.Write([]byte("RFB " + pv + "\n")); err != nil {
+	if _, err = c.c.Write([]byte(pv)); err != nil {
 		return err
 	}
 

--- a/client_auth.go
+++ b/client_auth.go
@@ -4,6 +4,12 @@ import (
 	"net"
 )
 
+const (
+	secTypeInvalid = iota
+	secTypeNone
+	secTypeVNCAuth
+)
+
 // A ClientAuth implements a method of authenticating with a remote server.
 type ClientAuth interface {
 	// SecurityType returns the byte identifier sent by the server to
@@ -16,10 +22,10 @@ type ClientAuth interface {
 }
 
 // ClientAuthNone is the "none" authentication. See 7.1.2
-type ClientAuthNone byte
+type ClientAuthNone struct{}
 
 func (*ClientAuthNone) SecurityType() uint8 {
-	return 1
+	return secTypeNone
 }
 
 func (*ClientAuthNone) Handshake(net.Conn) error {

--- a/client_test.go
+++ b/client_test.go
@@ -131,7 +131,7 @@ func TestSecurityResultHandshake(t *testing.T) {
 			t.Fatalf("securityResultHandshake() expected error for result %v", tt.result)
 		}
 		if err != nil {
-			if verr, ok := err.(*vncError); !ok {
+			if verr, ok := err.(*VNCError); !ok {
 				t.Errorf("securityResultHandshake() unexpected %v error: %v", reflect.TypeOf(err), verr)
 			}
 		}


### PR DESCRIPTION
This pull fleshes out many of the client protocol calls, validates proper protocol handling or reasonable failures, and includes some minor changes to make testing easier.

I'm doing this in preparation to support the basic auth RFB 003.003 as provided separately by xenserverarmy.