### PR TITLE
Add full support for RFB 3.3, with tests.

### DIFF
--- a/client.go
+++ b/client.go
@@ -321,6 +321,7 @@ func parseProtocolVersion(pv []byte) (uint, uint, error) {
 const (
 	// Client ProtocolVersions.
 	PROTO_VERS_UNSUP = "UNSUPPORTED"
+	PROTO_VERS_3_3   = "RFB 003.003\n"
 	PROTO_VERS_3_8   = "RFB 003.008\n"
 )
 
@@ -338,8 +339,12 @@ func (c *ClientConn) protocolVersionHandshake() error {
 		return err
 	}
 	pv := PROTO_VERS_UNSUP
-	if major == 3 && minor >= 8 {
-		pv = PROTO_VERS_3_8
+	if major == 3 {
+		if minor >= 8 {
+			pv = PROTO_VERS_3_8
+		} else if minor >= 3 {
+			pv = PROTO_VERS_3_3
+		}
 	}
 	if pv == PROTO_VERS_UNSUP {
 		return NewVNCError(fmt.Sprintf("ProtocolVersion handshake failed; unsupported version '%v'", string(protocolVersion[:])))

--- a/client.go
+++ b/client.go
@@ -524,14 +524,16 @@ func (c *ClientConn) readErrorReason() (string, error) {
 	return string(reason), nil
 }
 
-type vncError struct {
+// VNCError implements error interface.
+type VNCError struct {
 	s string
 }
 
+// NewVNCError returns a custom VNCError error.
 func NewVNCError(s string) error {
-	return &vncError{s}
+	return &VNCError{s}
 }
 
-func (e vncError) Error() string {
+func (e VNCError) Error() string {
 	return e.s
 }

--- a/client.go
+++ b/client.go
@@ -300,13 +300,7 @@ func (c *ClientConn) SetPixelFormat(format *PixelFormat) error {
 	return nil
 }
 
-const (
-	pvLen = 12 // ProtocolVersion message length.
-
-	// Supported protocol versions.
-	PROTO_VERS_UNSUP = "UNSUP"
-	PROTO_VERS_3_8   = "003.008"
-)
+const pvLen = 12 // ProtocolVersion message length.
 
 func parseProtocolVersion(pv []byte) (uint, uint, error) {
 	var major, minor uint
@@ -325,6 +319,12 @@ func parseProtocolVersion(pv []byte) (uint, uint, error) {
 
 	return major, minor, nil
 }
+
+const (
+	// Client ProtocolVersions.
+	PROTO_VERS_UNSUP = "UNSUPPORTED"
+	PROTO_VERS_3_8   = "RFB 003.008\n"
+)
 
 // protocolVersionHandshake implements §7.1.1 ProtocolVersion Handshake.
 func (c *ClientConn) protocolVersionHandshake() error {
@@ -348,7 +348,7 @@ func (c *ClientConn) protocolVersionHandshake() error {
 	}
 
 	// Respond with the version we will support
-	if _, err = c.c.Write([]byte("RFB " + pv + "\n")); err != nil {
+	if _, err = c.c.Write([]byte(pv)); err != nil {
 		return err
 	}
 

--- a/client_auth.go
+++ b/client_auth.go
@@ -4,6 +4,12 @@ import (
 	"net"
 )
 
+const (
+	secTypeInvalid = iota
+	secTypeNone
+	secTypeVNCAuth
+)
+
 // A ClientAuth implements a method of authenticating with a remote server.
 type ClientAuth interface {
 	// SecurityType returns the byte identifier sent by the server to
@@ -16,10 +22,10 @@ type ClientAuth interface {
 }
 
 // ClientAuthNone is the "none" authentication. See 7.1.2
-type ClientAuthNone byte
+type ClientAuthNone struct{}
 
 func (*ClientAuthNone) SecurityType() uint8 {
-	return 1
+	return secTypeNone
 }
 
 func (*ClientAuthNone) Handshake(net.Conn) error {

--- a/client_auth_test.go
+++ b/client_auth_test.go
@@ -1,11 +1,60 @@
 package vnc
 
-import "testing"
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
 
 func TestClientAuthNone_Impl(t *testing.T) {
 	var raw interface{}
 	raw = new(ClientAuthNone)
 	if _, ok := raw.(ClientAuth); !ok {
 		t.Fatal("ClientAuthNone doesn't implement ClientAuth")
+	}
+}
+
+func TestClientAuthVNC_Impl(t *testing.T) {
+	var raw interface{}
+	raw = new(ClientAuthVNC)
+	if _, ok := raw.(ClientAuth); !ok {
+		t.Fatal("ClientAuthVNC doesn't implement ClientAuth")
+	}
+}
+
+// wiresharkToChallenge converts VNC authentication challenge and response
+// values captured with Wireshark (https://www.wireshark.org) into usable byte
+// streams.
+func wiresharkToChallenge(h string) [vncAuthChallengeSize]byte {
+	var c [vncAuthChallengeSize]byte
+	r := strings.NewReplacer(":", "")
+	b, err := hex.DecodeString(r.Replace(h))
+	if err != nil {
+		return c
+	}
+	copy(c[:], b)
+	return c
+}
+
+func TestClientAuthVNCEncode(t *testing.T) {
+	tests := []struct {
+		pw                  string
+		challenge, response string
+	}{
+		{".", "7f:e2:e1:3d:a4:ae:10:9c:54:c5:5f:52:74:aa:db:31", "1d:86:92:71:1f:00:24:35:02:d3:91:ef:e9:bc:c5:d5"},
+		{"12345678", "13:8e:a4:2e:0e:66:f3:ad:2d:f3:08:c3:04:cd:c4:2a", "5b:e1:56:fa:49:49:ef:56:d3:f8:44:97:73:27:95:9f"},
+		{"abc123", "c6:30:45:d2:57:9e:e7:f2:f9:0c:62:3e:52:40:86:c6", "a3:63:59:e4:28:c8:7f:b3:45:2c:d7:e0:ca:d6:70:3e"},
+	}
+
+	for _, tt := range tests {
+		challenge := wiresharkToChallenge(tt.challenge)
+		a := ClientAuthVNC{tt.pw}
+		if err := a.encode(&challenge); err != nil {
+			t.Errorf("ClientAuthVNC.encode() failed: key=%v, err=%v", tt.pw, err)
+		}
+		response := wiresharkToChallenge(tt.response)
+		if challenge != response {
+			t.Errorf("ClientAuthVNC.encode() failed: key=%v got=%v, want=%v", tt.pw, challenge, response)
+		}
 	}
 }

--- a/client_auth_vnc.go
+++ b/client_auth_vnc.go
@@ -1,0 +1,72 @@
+/*
+ClientAuthVNC implements the ClientAuth interface to provide support for
+VNC Authentication.
+
+See http://tools.ietf.org/html/rfc6143#section-7.2.2 for more info.
+*/
+package vnc
+
+import (
+	"crypto/des"
+	"encoding/binary"
+	"net"
+)
+
+// ClientAuthVNC is the standard password authentication
+type ClientAuthVNC struct {
+	Password string
+}
+
+func (*ClientAuthVNC) SecurityType() uint8 {
+	return secTypeVNCAuth
+}
+
+// 7.2.2. VNC Authentication uses a 16-byte challenge.
+const vncAuthChallengeSize = 16
+
+func (auth *ClientAuthVNC) Handshake(conn net.Conn) error {
+
+	if auth.Password == "" {
+		return NewVNCError("securityHandshake: handshake failed; no password provided for VNCAuth.")
+	}
+
+	// Read challenge block
+	var challenge [vncAuthChallengeSize]byte
+	if err := binary.Read(conn, binary.BigEndian, &challenge); err != nil {
+		return err
+	}
+
+	auth.encode(&challenge)
+
+	// Send the encrypted challenge back to server
+	if err := binary.Write(conn, binary.BigEndian, challenge); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (auth *ClientAuthVNC) encode(c *[vncAuthChallengeSize]byte) error {
+	// Copy password string to 8 byte 0-padded slice
+	key := make([]byte, 8)
+	copy(key, auth.Password)
+
+	// Each byte of the password needs to be reversed. This is a
+	// non RFC-documented behaviour of VNC clients and servers
+	for i := range key {
+		key[i] = (key[i]&0x55)<<1 | (key[i]&0xAA)>>1 // Swap adjacent bits
+		key[i] = (key[i]&0x33)<<2 | (key[i]&0xCC)>>2 // Swap adjacent pairs
+		key[i] = (key[i]&0x0F)<<4 | (key[i]&0xF0)>>4 // Swap the 2 halves
+	}
+
+	// Encrypt challenge with key.
+	cipher, err := des.NewCipher(key)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < vncAuthChallengeSize; i += cipher.BlockSize() {
+		cipher.Encrypt(c[i:i+cipher.BlockSize()], c[i:i+cipher.BlockSize()])
+	}
+
+	return nil
+}

--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"net"
 	"reflect"
 	"testing"
@@ -88,6 +89,7 @@ func TestParseProtocolVersion(t *testing.T) {
 		if err != nil && !tt.isErr {
 			t.Fatalf("parseProtocolVersion(%v) unexpected error %v", tt.proto, err)
 		}
+		// TODO(kward): validate VNCError thrown.
 		if err == nil && tt.isErr {
 			t.Fatalf("parseProtocolVersion(%v) expected error", tt.proto)
 		}
@@ -127,7 +129,7 @@ func TestProtocolVersionHandshake(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Validate server message.
+		// Validate server message handling.
 		err := conn.protocolVersionHandshake()
 		if err == nil && !tt.ok {
 			t.Fatalf("protocolVersionHandshake() expected error for server protocol version %v", tt.server)
@@ -150,56 +152,158 @@ func TestProtocolVersionHandshake(t *testing.T) {
 	}
 }
 
-func TestSecurityHandshake(t *testing.T) {
+func writeVNCAuthChallenge(w io.Writer) error {
+	var c [vncAuthChallengeSize]uint8
+	for i := 0; i < vncAuthChallengeSize; i++ {
+		c[i] = uint8(i)
+	}
+	if err := binary.Write(w, binary.BigEndian, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readVNCAuthChallenge(r io.Reader) error {
+	var c [vncAuthChallengeSize]uint8
+	if err := binary.Read(r, binary.BigEndian, &c); err != nil {
+		return fmt.Errorf("error reading back VNCAuth challenge")
+	}
+	return nil
+}
+
+func TestSecurityHandshake33(t *testing.T) {
 	tests := []struct {
-		server  []uint8
-		client  []ClientAuth
-		secType uint8
-		ok      bool
+		server uint32
+		ok     bool
+		reason string
 	}{
 		//-- Supported security types. --
-		// Both server and client support the None security type.
-		{[]uint8{secTypeNone}, []ClientAuth{&ClientAuthNone{}}, secTypeNone, true},
-		// Server supports None and VNCAuth, client supports only None.
-		{[]uint8{secTypeVNCAuth, secTypeNone}, []ClientAuth{&ClientAuthNone{}}, secTypeNone, true},
+		// Server supports None.
+		{secTypeNone, true, ""},
+		// Server supports VNCAuth.
+		{secTypeVNCAuth, true, ""},
 		//-- Unsupported security types. --
-		// Server provided no security types.
-		{[]uint8{}, []ClientAuth{&ClientAuthNone{}}, secTypeInvalid, false},
-		// Client and server don't support same security types.
-		{[]uint8{secTypeVNCAuth}, []ClientAuth{&ClientAuthNone{}}, secTypeInvalid, false},
+		{secTypeInvalid, false, "some reason"},
+		{255, false, ""},
 	}
 
 	mockConn := &MockConn{}
 	conn := &ClientConn{
-		c:      mockConn,
-		config: &ClientConfig{},
+		c:               mockConn,
+		config:          NewClientConfig("."),
+		protocolVersion: PROTO_VERS_3_3,
 	}
 
 	for _, tt := range tests {
 		mockConn.Reset()
-		if len(tt.server) > 0 {
-			if err := binary.Write(conn.c, binary.BigEndian, uint8(len(tt.server))); err != nil {
+		if err := binary.Write(conn.c, binary.BigEndian, tt.server); err != nil {
+			t.Fatal(err)
+		}
+		if len(tt.reason) > 0 {
+			if err := binary.Write(conn.c, binary.BigEndian, uint32(len(tt.reason))); err != nil {
 				t.Fatal(err)
 			}
-			if err := binary.Write(conn.c, binary.BigEndian, []byte(tt.server)); err != nil {
+			if err := binary.Write(conn.c, binary.BigEndian, []byte(tt.reason)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if tt.server == secTypeVNCAuth {
+			if err := writeVNCAuthChallenge(conn.c); err != nil {
 				t.Fatal(err)
 			}
 		}
 
-		// Validate server message.
-		conn.config.Auth = tt.client
+		// Validate server message handling.
 		err := conn.securityHandshake()
 		if err == nil && !tt.ok {
 			t.Fatalf("securityHandshake() expected error for server auth %v", tt.server)
-		}
-		if len(tt.server) == 0 {
-			// The protocol was incomplete; no point in checking values.
-			continue
 		}
 		if err != nil {
 			if verr, ok := err.(*VNCError); !ok {
 				t.Errorf("securityHandshake() unexpected %v error: %v", reflect.TypeOf(err), verr)
 			}
+		}
+		if !tt.ok {
+			continue
+		}
+
+		// Validate client response.
+		if tt.server == secTypeVNCAuth {
+			if err := readVNCAuthChallenge(conn.c); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestSecurityHandshake38(t *testing.T) {
+	tests := []struct {
+		server  []uint8
+		client  []ClientAuth
+		secType uint8
+		ok      bool
+		reason  string
+	}{
+		//-- Supported security types. --
+		// Server and client support None.
+		{[]uint8{secTypeNone}, []ClientAuth{&ClientAuthNone{}}, secTypeNone, true, ""},
+		// Server and client support VNCAuth.
+		{[]uint8{secTypeVNCAuth}, []ClientAuth{&ClientAuthVNC{"."}}, secTypeVNCAuth, true, ""},
+		// Server and client both support VNCAuth and None.
+		{[]uint8{secTypeVNCAuth, secTypeNone}, []ClientAuth{&ClientAuthVNC{"."}, &ClientAuthNone{}}, secTypeVNCAuth, true, ""},
+		// Server supports unknown #255, VNCAuth and None.
+		{[]uint8{255, secTypeVNCAuth, secTypeNone}, []ClientAuth{&ClientAuthVNC{"."}, &ClientAuthNone{}}, secTypeVNCAuth, true, ""},
+		//-- Unsupported security types. --
+		// Server provided no valid security types.
+		{[]uint8{secTypeInvalid}, []ClientAuth{}, secTypeInvalid, false, "some reason"},
+		// Client and server don't support same security types.
+		{[]uint8{secTypeVNCAuth}, []ClientAuth{&ClientAuthNone{}}, secTypeInvalid, false, ""},
+		// Server supports only unknown #255.
+		{[]uint8{255}, []ClientAuth{&ClientAuthNone{}}, secTypeInvalid, false, ""},
+	}
+
+	mockConn := &MockConn{}
+	conn := &ClientConn{
+		c:               mockConn,
+		config:          &ClientConfig{},
+		protocolVersion: PROTO_VERS_3_8,
+	}
+
+	for _, tt := range tests {
+		mockConn.Reset()
+		if err := binary.Write(conn.c, binary.BigEndian, uint8(len(tt.server))); err != nil {
+			t.Fatal(err)
+		}
+		if err := binary.Write(conn.c, binary.BigEndian, []byte(tt.server)); err != nil {
+			t.Fatal(err)
+		}
+		if len(tt.reason) > 0 {
+			if err := binary.Write(conn.c, binary.BigEndian, uint32(len(tt.reason))); err != nil {
+				t.Fatal(err)
+			}
+			if err := binary.Write(conn.c, binary.BigEndian, []byte(tt.reason)); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if tt.secType == secTypeVNCAuth {
+			if err := writeVNCAuthChallenge(conn.c); err != nil {
+				t.Fatal(err)
+			}
+		}
+		conn.config.Auth = tt.client
+
+		// Validate server message handling.
+		err := conn.securityHandshake()
+		if err == nil && !tt.ok {
+			t.Fatalf("securityHandshake() expected error for server auth %v", tt.server)
+		}
+		if err != nil {
+			if verr, ok := err.(*VNCError); !ok {
+				t.Errorf("securityHandshake() unexpected %v error: %v", reflect.TypeOf(err), verr)
+			}
+		}
+		if !tt.ok {
+			continue
 		}
 
 		// Validate client response.
@@ -207,6 +311,11 @@ func TestSecurityHandshake(t *testing.T) {
 		err = binary.Read(conn.c, binary.BigEndian, &secType)
 		if secType != tt.secType {
 			t.Errorf("securityHandshake() secType: got = %v, want = %v", secType, tt.secType)
+		}
+		if tt.secType == secTypeVNCAuth {
+			if err := readVNCAuthChallenge(conn.c); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 }
@@ -239,7 +348,7 @@ func TestSecurityResultHandshake(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Validate server message.
+		// Validate server message handling.
 		err := conn.securityResultHandshake()
 		if err == nil && !tt.ok {
 			t.Fatalf("securityResultHandshake() expected error for result %v", tt.result)
@@ -339,7 +448,7 @@ func TestServerInit(t *testing.T) {
 			}
 		}
 
-		// Validate server message.
+		// Validate server message handling.
 		err := conn.serverInit()
 		if tt.eof < dn && err == nil {
 			t.Fatalf("serverInit() expected error")

--- a/client_test.go
+++ b/client_test.go
@@ -131,7 +131,7 @@ func TestSecurityResultHandshake(t *testing.T) {
 			t.Fatalf("securityResultHandshake() expected error for result %v", tt.result)
 		}
 		if err != nil {
-			if verr, ok := err.(*vncError); !ok {
+			if verr, ok := err.(*VNCError); !ok {
 				t.Errorf("securityResultHandshake() unexpected %v error: %v", reflect.TypeOf(err), verr)
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -51,7 +51,7 @@ func TestClient_LowMajorVersion(t *testing.T) {
 }
 
 func TestClient_LowMinorVersion(t *testing.T) {
-	nc, err := net.Dial("tcp", newMockServer(t, "003.007"))
+	nc, err := net.Dial("tcp", newMockServer(t, "003.002"))
 	if err != nil {
 		t.Fatalf("error connecting to mock server: %s", err)
 	}
@@ -107,10 +107,11 @@ func TestProtocolVersionHandshake(t *testing.T) {
 		ok     bool
 	}{
 		// Supported versions.
+		{"RFB 003.003\n", "RFB 003.003\n", true},
+		{"RFB 003.006\n", "RFB 003.003\n", true},
 		{"RFB 003.008\n", "RFB 003.008\n", true},
 		{"RFB 003.389\n", "RFB 003.008\n", true},
 		// Unsupported versions.
-		{server: "RFB 003.003\n", ok: false},
 		{server: "RFB 002.009\n", ok: false},
 	}
 


### PR DESCRIPTION
This code includes VNCAuth support as provided in the separate DES inclusion pull.

This work is based on the work of xenserverarmy, with some code refactoring.